### PR TITLE
Enable User to Scroll Through Options on Notification Modal

### DIFF
--- a/src/components/NotificationsSwitch/index.jsx
+++ b/src/components/NotificationsSwitch/index.jsx
@@ -104,7 +104,7 @@ export default function NotificationsSwitch() {
 
 const useStyles = makeStyles((theme) => ({
   wrapper: { position: "relative" },
-  modalWrapper: { marginRight: '70px', marginTop: '-65px'},
+  modalWrapper: {},
   announcementsButton: {
     color: "#f3efcd !important",
     backgroundColor: "#164120 !important",

--- a/src/components/NotificationsSwitch/index.jsx
+++ b/src/components/NotificationsSwitch/index.jsx
@@ -104,7 +104,7 @@ export default function NotificationsSwitch() {
 
 const useStyles = makeStyles((theme) => ({
   wrapper: { position: "relative" },
-  modalWrapper: {},
+  modalWrapper: { marginRight: '70px', marginTop: '-65px'},
   announcementsButton: {
     color: "#f3efcd !important",
     backgroundColor: "#164120 !important",

--- a/src/components/NotificationsSwitch/index.jsx
+++ b/src/components/NotificationsSwitch/index.jsx
@@ -104,7 +104,7 @@ export default function NotificationsSwitch() {
 
 const useStyles = makeStyles((theme) => ({
   wrapper: { position: "relative" },
-  modalWrapper: {},
+  modalWrapper: { marginRight: '70px', marginTop: '-65px'},
   announcementsButton: {
     color: "#f3efcd !important",
     backgroundColor: "#164120 !important",
@@ -127,7 +127,6 @@ const useStyles = makeStyles((theme) => ({
     color: "#f3efcd",
     fontFamily: "Space Grotesk",
     fontWeight: "600",
-    position: "absolute",
     right: 0,
     backgroundColor: "#164120",
     padding: "1rem",
@@ -135,5 +134,8 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
+    overflowY: "auto",
+    maxHeight: "100vh",
+    width: "500px"
   },
 }));


### PR DESCRIPTION
A user can now scroll through to see either Dialect or Notifi as options in the notification modal.

Solution: 

https://user-images.githubusercontent.com/108922885/194155435-d6e6d3cb-6159-4114-bb39-bc7178c18cde.mov
